### PR TITLE
removed unnecessary `asynchronous` decorator.

### DIFF
--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -96,7 +96,6 @@ class ImageHandler(tornado.web.RequestHandler):
         "png": "image/png",
         "webp": "image/webp"}
 
-    @tornado.web.asynchronous
     @tornado.gen.coroutine
     def get(self):
         self._validate_request()


### PR DESCRIPTION
**Summary:**
- removed unnecessary `asynchronous` decorator.

According to asynchronous method documentation, `asynchronous` is unnecessary if used with `@gen.coroutine`:

``` python
def asynchronous(method):
    """Wrap request handler methods with this if they are asynchronous.

    This decorator is unnecessary if the method is also decorated with
    ``@gen.coroutine`` (it is legal but unnecessary to use the two
    decorators together, in which case ``@asynchronous`` must be
    first).
```
