### PR TITLE
Custom application doesn't get command line arguments

### DIFF
--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -290,12 +290,12 @@ class ImageHandler(tornado.web.RequestHandler):
             raise errors.HostError("Invalid host")
 
 
-def main(app=None):
+def main(app_class=None):
     tornado.options.parse_command_line()
     if options.debug:
         logger.setLevel(logging.DEBUG)
     server = tornado.httpserver.HTTPServer(
-        app if app else PilboxApplication())
+        app_class() if app_class else PilboxApplication())
     logger.info("Starting server...")
     try:
         server.bind(options.port)


### PR DESCRIPTION
There is an issue in main method. When using with customized `PilboxApplication` passed through `app` param, this application doesn't receive arguments from command line. The problem arises because `tornado.options.parse_command_line()` runs after application instantiation. It should run before application instantiation, but with custom application it isn't possible.