### PR TITLE
Proxy support

### DIFF
--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -170,7 +170,7 @@ class ImageHandler(tornado.web.RequestHandler):
         client = tornado.httpclient.AsyncHTTPClient(
             max_clients=self.settings.get("max_requests"))
         try:
-            if "proxy_host" in self.settings:
+            if self.settings.get("proxy_host"):
                 resp = yield client.fetch(
                     url,
                     request_timeout=self.settings.get("timeout"),


### PR DESCRIPTION
Hello there!

A while back @lneves asked me to take a look at pilbox and merge a little patch he'd done for proxy support (we need proxy support since we're running pilbox on back-end servers that have requests proxied to them from Varnish but has no direct outbound access).

I kept it on my to-do list until I had a spare moment, and today was the day (it took me well over two months to get round to this...).

I took a deeper look around and figured what made sense (and had the least impact on your code) was being able to specify the proxy on the command line -- we actually read it from the `http_proxy` environment variable, but since we run pilbox from a supervisor script that's easy enough to tack in there.

Another tweak we did was to enable Tornado's `curl_httpclient` when using the proxy. It's also slightly more efficient to use that by default, but although we have `python-pycurl` installed, you might not want that extra dependency (from what I could gather, it actually being a dependency depends on how you install Tornado...)

Anyway, a word of thanks from the team here at SAPO - you have a great solution here.
