### PR TITLE
Allow different cropping rules based on target orientation

### DIFF
--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -79,6 +79,7 @@ define("optimize", help="default to optimize when saving", type=int)
 define("position", help="default cropping position")
 define("progressive", help="default to progressive when saving", type=int)
 define("quality", help="default jpeg quality, 0-100 or keep")
+define("orientation", help="default target orientation")
 
 logger = logging.getLogger("tornado.application")
 
@@ -103,6 +104,7 @@ class PilboxApplication(tornado.web.Application):
             position=options.position,
             progressive=options.progressive,
             quality=options.quality,
+            orientation=options.orientation,
             max_requests=options.max_requests,
             timeout=options.timeout,
             implicit_base_url=options.implicit_base_url,
@@ -260,7 +262,8 @@ class ImageHandler(tornado.web.RequestHandler):
             dict(mode=self.get_argument("mode"),
                  filter=self.get_argument("filter"),
                  position=self.get_argument("pos"),
-                 background=self.get_argument("bg")))
+                 background=self.get_argument("bg"),
+                 orientation=self.get_argument("orientation")))
 
     def _get_rotate_options(self):
         return self._get_options(

--- a/pilbox/image.py
+++ b/pilbox/image.py
@@ -75,7 +75,7 @@ class Image(object):
 
     _DEFAULTS = dict(background="fff", expand=False, filter="antialias",
                      format=None, mode="crop", optimize=False,
-                     position="center", quality=90, progressive=False)
+                     position="center", quality=90, progressive=False, orientation="default")
     _CLASSIFIER_PATH = os.path.join(
         os.path.dirname(__file__), "frontalface.xml")
 
@@ -267,7 +267,11 @@ class Image(object):
             self.img, size, opts["pil"]["filter"], 0, pos)
 
     def _fill(self, size, opts):
-        self._clip(size, opts)
+        if (opts["pil"]["orientation"] == "horizontal" and self.img.size[1] < self.img.size[0]) or (opts["pil"]["orientation"] == "vertical" and self.img.size[0] < self.img.size[1]):
+          self._crop(size, opts)
+        else:
+          self._clip(size, opts)
+
         if self.img.size == size:
             return  # No need to fill
         x = max(int((size[0] - self.img.size[0]) / 2.0), 0)
@@ -334,7 +338,8 @@ class Image(object):
         opts["pil"] = dict(
             filter=_filters_to_pil.get(opts["filter"]),
             format=_formats_to_pil.get(opts["format"]),
-            position=Image._get_custom_position(opts["position"]))
+            position=Image._get_custom_position(opts["position"]),
+            orientation=opts["orientation"])
 
         if not opts["pil"]["position"]:
             opts["pil"]["position"] = _positions_to_ratios.get(
@@ -403,6 +408,7 @@ def main():
     define("optimize", help="default to optimize when saving", type=int)
     define("quality", help="default jpeg quality, 0-100 or keep")
     define("progressive", help="default to progressive when saving", type=int)
+    define("orientation", help="default orientation", type=str)
 
     args = parse_command_line()
     if not args:


### PR DESCRIPTION
This commit adds to option to specify a target orientation when using the "fill" mode- "horizontal" or "vertical". it allows you to tell Pilbox to treat images differently depending on whether the source image itself is portrait or landscape.

Here's an example, using the "horizontal" target orientation:

![screen shot 2015-03-11 at 10 02 10](https://cloud.githubusercontent.com/assets/1673899/6594069/b89a52ae-c7d5-11e4-868a-560978a5c21e.png)

Notice how the three images that were horizontal to start with are cropped at the top and bottom so that they completely fill the space, but the image on the far right that was vertical to start with gets scaled.

Without this option, you'd EITHER:
a) Always end up with white margins, even on the images that were horizontal to start with, because their aspect ratio was ever so slightly different from the target
or
b) Vertical images like the avocado would just get cropped in the middle and you'd get a ridiculously zoomed in thing that lost most of the image