### PR TITLE
Region operation support optional resize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:latest
+
+MAINTAINER Jacopo Daeli <jacopo.daeli@gmail.com>
+
+ENV PILBOX_DIR=/pilbox
+
+EXPOSE 8888
+
+RUN sudo apt-get update -qq && \
+  apt-get install python -yqq && \
+  apt-get install python-dev -yqq && \
+  apt-get install python-setuptools -yqq && \
+  apt-get install python-pip -yqq && \
+  apt-get install python-numpy -yqq && \
+  apt-get install python-opencv -yqq && \
+  apt-get install python-pycurl -yqq && \
+  apt-get install libjpeg-dev -yqq && \
+  apt-get install libfreetype6-dev -yqq && \
+  apt-get install zlib1g-dev -yqq && \
+  apt-get install libwebp-dev -yqq && \
+  apt-get install liblcms2-dev -yqq && \
+  apt-get install python -yqq && \
+  apt-get install python -yqq && \
+  pip install Pillow==2.8.1 && \
+  pip install tornado==4.0.2 && \
+  pip install coverage==3.6 && \
+  pip install pep8==1.6.2 && \
+  pip install pyflakes==0.8.1 && \
+  pip install pyandoc==0.0.1 && \
+  pip install sphinx-me==0.2.1
+
+COPY . /pilbox
+
+WORKDIR /pilbox
+
+CMD ["python", "-m", "pilbox.app", "--debug"]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,11 @@
 
 Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "precise64"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  # config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,11 +3,11 @@
 
 Vagrant.configure("2") do |config|
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "precise64"
+  config.vm.box = "ubuntu/trusty64"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  # config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -166,6 +166,8 @@ class ImageHandler(tornado.web.RequestHandler):
             Image.validate_degree(self.get_argument("deg"))
             opts.update(self._get_rotate_options())
         if "region" in ops:
+            Image.validate_dimensions(
+                self.get_argument("w"), self.get_argument("h"), True)
             Image.validate_rectangle(self.get_argument("rect"))
 
         Image.validate_options(opts)
@@ -228,7 +230,8 @@ class ImageHandler(tornado.web.RequestHandler):
         return (self._image_save(image), image.img.format)
 
     def _image_region(self, image):
-        image.region(self.get_argument("rect").split(","))
+        opts = self._get_resize_options()
+        image.region(self.get_argument("rect").split(","), self.get_argument("w"), self.get_argument("h"), **opts)
 
     def _image_resize(self, image):
         opts = self._get_resize_options()

--- a/pilbox/image.py
+++ b/pilbox/image.py
@@ -97,7 +97,7 @@ class Image(object):
         self._orig_format = self.img.format
 
     @staticmethod
-    def validate_dimensions(width, height, is_region):
+    def validate_dimensions(width, height, is_region=False):
         if not width and not height and not is_region:
             raise errors.DimensionsError("Missing dimensions")
         elif width and not str(width).isdigit():

--- a/pilbox/image.py
+++ b/pilbox/image.py
@@ -167,7 +167,7 @@ class Image(object):
             raise errors.RetainError(
                 "Invalid retain: %s" % str(opts["retain"]))
 
-    def region(self, rect, width, height, **kwargs):
+    def region(self, rect, width=False, height=False, **kwargs):
         """ Selects a sub-region of the image using the supplied rectangle,
             x, y, width, height.
         """
@@ -479,7 +479,7 @@ def main():
     elif options.operation == "rotate":
         image.rotate(options.degree, expand=options.expand)
     elif options.operation == "region":
-        image.region(options.rect.split(","))
+        image.region(options.rect.split(","), options.width, options.height)
 
     stream = image.save(format=options.format,
                         optimize=options.optimize,

--- a/pilbox/image.py
+++ b/pilbox/image.py
@@ -97,8 +97,8 @@ class Image(object):
         self._orig_format = self.img.format
 
     @staticmethod
-    def validate_dimensions(width, height):
-        if not width and not height:
+    def validate_dimensions(width, height, is_region):
+        if not width and not height and not is_region:
             raise errors.DimensionsError("Missing dimensions")
         elif width and not str(width).isdigit():
             raise errors.DimensionsError("Invalid width: %s" % width)
@@ -167,7 +167,7 @@ class Image(object):
             raise errors.RetainError(
                 "Invalid retain: %s" % str(opts["retain"]))
 
-    def region(self, rect):
+    def region(self, rect, width, height, **kwargs):
         """ Selects a sub-region of the image using the supplied rectangle,
             x, y, width, height.
         """
@@ -176,6 +176,12 @@ class Image(object):
         if box[2] > self.img.size[0] or box[3] > self.img.size[1]:
             raise errors.RectangleError("Region out-of-bounds")
         self.img = self.img.crop(box)
+
+        if width or height:
+            opts = Image._normalize_options(kwargs)
+            size = self._get_size(width, height)
+            self._scale(size, opts)
+
         return self
 
     def resize(self, width, height, **kwargs):


### PR DESCRIPTION
Since the `region` operation doesn't allow any resize on the cropped region and since concatenate operations are not supported (`region` +`resize`, for example) I added an optional `resize (scale)` when performing a region operation.

The region operation now accepts `w` and `h` as optional parameters, and if at least one of them is stated, `pilbox` will scale the cropped region.