### PR TITLE
Add ca_certs config option for setting custom CA cert path.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,8 @@ To see a list of all available options, run
       --allowed_hosts            list of allowed hosts (default [])
       --allowed_operations       list of allowed operations (default [])
       --background               default hexadecimal bg color (RGB or ARGB)
+      --ca_certs                 filename of CA certificates in PEM format,
+                                 or None to use defaults
       --client_key               client key
       --client_name              client name
       --config                   path to configuration file

--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -60,8 +60,8 @@ define("max_requests", help="max concurrent requests", type=int, default=40)
 define("timeout", help="request timeout in seconds", type=float, default=10)
 define("implicit_base_url", help="prepend protocol/host to url paths")
 define("ca_certs",
-        help="override filename of CA certificates in PEM format",
-        default=None)
+       help="override filename of CA certificates in PEM format",
+       default=None)
 define("validate_cert", help="validate certificates", type=bool, default=True)
 define("proxy_host", help="proxy hostname")
 define("proxy_port", help="proxy port", type=int)

--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -59,6 +59,7 @@ define("allowed_operations", help="valid ops", default=[], multiple=True)
 define("max_requests", help="max concurrent requests", type=int, default=40)
 define("timeout", help="request timeout in seconds", type=float, default=10)
 define("implicit_base_url", help="prepend protocol/host to url paths")
+define("ca_certs", help="filename of CA certificates in PEM format, or None to use defaults", default=None)
 define("validate_cert", help="validate certificates", type=bool, default=True)
 define("proxy_host", help="proxy hostname")
 define("proxy_port", help="proxy port", type=int)
@@ -108,6 +109,7 @@ class PilboxApplication(tornado.web.Application):
             max_requests=options.max_requests,
             timeout=options.timeout,
             implicit_base_url=options.implicit_base_url,
+            ca_certs=options.ca_certs,
             validate_cert=options.validate_cert,
             content_type_from_image=options.content_type_from_image,
             proxy_host=options.proxy_host,
@@ -183,6 +185,7 @@ class ImageHandler(tornado.web.RequestHandler):
             resp = yield client.fetch(
                 url,
                 request_timeout=self.settings.get("timeout"),
+                ca_certs=self.settings.get("ca_certs"),
                 validate_cert=self.settings.get("validate_cert"),
                 proxy_host=self.settings.get("proxy_host"),
                 proxy_port=self.settings.get("proxy_port"))

--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -59,7 +59,9 @@ define("allowed_operations", help="valid ops", default=[], multiple=True)
 define("max_requests", help="max concurrent requests", type=int, default=40)
 define("timeout", help="request timeout in seconds", type=float, default=10)
 define("implicit_base_url", help="prepend protocol/host to url paths")
-define("ca_certs", help="filename of CA certificates in PEM format, or None to use defaults", default=None)
+define("ca_certs",
+        help="override filename of CA certificates in PEM format",
+        default=None)
 define("validate_cert", help="validate certificates", type=bool, default=True)
 define("proxy_host", help="proxy hostname")
 define("proxy_port", help="proxy port", type=int)


### PR DESCRIPTION
This was necessary to solve an issue on a Heroku deploy where the CA default bundle was not being detected automatically.

This option may be useful to others as well.

It would be really helpful if you can merge it in and do a release, so I don't have to specify my fork's URL in my dependencies. Thanks! :-)