### PR TITLE
Allows you to pass the URL in the path

### DIFF
--- a/pilbox/test/app_test.py
+++ b/pilbox/test/app_test.py
@@ -155,14 +155,14 @@ class _AppAsyncMixin(object):
 
 
 class _PilboxTestApplication(PilboxApplication):
-    def get_handlers(self):
+    def get_handlers(self, settings={}):
         path = os.path.join(os.path.dirname(__file__), "data")
         handlers = [(r"/test/data/test-delayed.jpg", _DelayedHandler),
                     (r"/test/data/test-user-agent.jpg", _UserAgentHandler),
                     (r"/test/data/(.*)",
                      tornado.web.StaticFileHandler,
                      {"path": path})]
-        handlers.extend(super(_PilboxTestApplication, self).get_handlers())
+        handlers.extend(super(_PilboxTestApplication, self).get_handlers(settings))
         return handlers
 
 


### PR DESCRIPTION
This allows you to act as a true transparent proxy
```
$ python -m pilbox.app --read_url_from_path=true --implicit_base_url=https://www.google.co.in
$ open http://localhost:8888/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png?w=640
```

See #59 for how to get rid of the w parameter by default