### PR TITLE
Support running pilbox.image in py2 or py3

### DIFF
--- a/pilbox/image.py
+++ b/pilbox/image.py
@@ -518,7 +518,10 @@ def main():
                         quality=options.quality,
                         progressive=options.progressive,
                         preserve_exif=options.preserve_exif)
-    sys.stdout.write(stream.read())
+    try:
+        sys.stdout.buffer.write(stream.read())
+    except AttributeError:
+        sys.stdout.write(stream.read())
     stream.close()
 
 


### PR DESCRIPTION
If the README example of running the image module is performed using python 3.x a traceback will occur:

```
$ python -m pilbox.image --width=300 --height=300 http://i.imgur.com/zZ8XmBA.jpg > /tmp/foo.jpg
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 184, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python3/3.5.2_3/Frameworks/Python.framework/Versions/3.5/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/saschwarz/dev/pilbox/pilbox/image.py", line 529, in <module>
    main()
  File "/Users/saschwarz/dev/pilbox/pilbox/image.py", line 524, in main
    sys.stdout.write(stream.read())
TypeError: write() argument must be str, not bytes
```

This modification allows either python version to be used.