### PR TITLE
Conversion of GIF/PNG to JPEG raises 'cannot write mode P as JPEG'

### DIFF
--- a/pilbox/image.py
+++ b/pilbox/image.py
@@ -277,6 +277,12 @@ class Image(object):
             if opts["quality"] == "keep":
                 save_kwargs["quality"] = "keep"
 
+        if fmt == "JPEG" and self.img.mode == 'P':
+            # Converting old GIF and PNG files to JPEG can raise
+            # IOError: cannot write mode P as JPEG
+            # https://mail.python.org/pipermail/python-list/2000-May/036017.html
+            self.img = self.img.convert("RGB")
+
         try:
             self.img.save(outfile, fmt, **save_kwargs)
         except IOError as e:


### PR DESCRIPTION
I'm using pilbox as a proxy to convert images created by some older software that output to 
PNG and GIF. For my purposes I need to convert them to JPEG format. Here is the error I get when using either the command line or the tornado application:

```
$ python  -m pilbox.image --width=300 --height=300 --format=jpeg http://agilitycoursemaps.com/Content/courseMapImages/636373724322750029_Sun11%20-%20Starters%20Standard.gif
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saschwarz/dev/pilbox/pilbox/image.py", line 526, in <module>
    main()
  File "/Users/saschwarz/dev/pilbox/pilbox/image.py", line 520, in main
    preserve_exif=options.preserve_exif)
  File "/Users/saschwarz/dev/pilbox/pilbox/image.py", line 283, in save
    raise errors.ImageSaveError(str(e))
pilbox.errors.ImageSaveError: HTTP 415: Unsupported Media Type (cannot write mode P as JPEG)
```

I've added an explicit check for the scenario where the output format is JPEG and the mode of the input file is 'P' for Palette. I then apply the solution proposed here:
https://mail.python.org/pipermail/python-list/2000-May/036017.html
