### PR TITLE
Add `workers` config option to set number of procs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,7 @@ To see a list of all available options, run
       --timeout                  timeout of requests in seconds (default 10)
       --user_agent               user agent
       --validate_cert            validate certificates (default True)
+      --workers                  number of worker processes (0 = auto) (default 0)
 
 
 Calling
@@ -407,6 +408,9 @@ below is an example configuration.
     # General settings
     port = 8888
 
+    # One worker process per CPU core
+    workers = 0
+
     # Set client name and key if the application requires signed requests. The
     # client must sign the request using the client_key, see README for
     # instructions.
@@ -488,6 +492,14 @@ following to the configuration.
     quality = 75
 
 If you wish to improve performance further and are using an x86 platform, you may want to consider using `Pillow-SIMD <https://github.com/uploadcare/pillow-simd/>`_. Follow the steps in `Installation <https://github.com/uploadcare/pillow-simd#installation>`_ and it should function as a drop-in replacement for ``Pillow``. To avoid any incompatibility issues, use the same version of ``Pillow-SIMD`` as is being used for ``Pillow``.
+
+Another setting that's helpful for fine-tuning performance and memory
+usage is the ``workers`` setting to set the number of Tornado worker
+processes. The default setting of ``0`` spawns one worker process per
+CPU core which can lead to high memory usage and reduced performance
+due to swapping on low-memory configurations. For Heroku deployments
+limiting the number of worker processes to 2-3 for the lower-end dynos
+helped smooth out application response time.
 
 Extension
 =========

--- a/pilbox/app.py
+++ b/pilbox/app.py
@@ -48,6 +48,8 @@ define("config", help="path to configuration file",
        callback=lambda path: parse_config_file(path, final=False))
 define("debug", help="run in debug mode", type=bool, default=False)
 define("port", help="run on the given port", type=int, default=8888)
+define("workers", help="number of worker processes (0 = auto)",
+       type=int, default=0)
 
 # security related settings
 define("client_name", help="client name")
@@ -351,7 +353,7 @@ def start_server(app=None):  # pragma: no cover
     logger.info("Starting server...")
     try:
         server.bind(options.port)
-        server.start(1 if options.debug else 0)
+        server.start(1 if options.debug else options.workers)
         tornado.ioloop.IOLoop.instance().start()
     except KeyboardInterrupt:
         tornado.ioloop.IOLoop.instance().stop()


### PR DESCRIPTION
Thanks for this awesome project! I'm running Pilbox as the image resizing service for [realpython.com](https://realpython.com) (see https://github.com/realpython/robocrop), deployed on Heroku.

I ran into issues with memory usage because Tornado would decide to spawn 8 worker processes on a low-end Heroku dyno. The sweet spot seems to be at 3 worker processes for this setup.

I made the number of Tornado workers configurable in https://github.com/realpython/robocrop/blob/master/app.py and this fixed our memory usage issues and smoothed out our response time when running Pilbox on Heroku.

This PR ports that functionality back into mainline Pilbox by adding a `workers` config option.

Keep the default of starting one worker per CPU core:

```console
$ python -m pilbox.app
[I 180808 12:47:29 app:353] Starting server...
[I 180808 12:47:29 process:128] Starting 4 processes
```

`--workers N` allows spawning a predefined number of workers:

```console
$ python -m pilbox.app --workers=2
[I 180808 12:47:42 app:353] Starting server...
[I 180808 12:47:42 process:128] Starting 2 processes

$ python -m pilbox.app --workers=8
[I 180808 12:47:58 app:353] Starting server...
[I 180808 12:47:58 process:128] Starting 8 processes
```

Hope this is helpful & please let me know if you need any other changes on the PR in order to move forward 🙂 